### PR TITLE
通过获取类的RequestMapping注解来判断当前请求是否需要登录

### DIFF
--- a/kafka-manager-common/src/main/java/com/xiaojukeji/kafka/manager/common/constant/ApiPrefix.java
+++ b/kafka-manager-common/src/main/java/com/xiaojukeji/kafka/manager/common/constant/ApiPrefix.java
@@ -11,8 +11,6 @@ public class ApiPrefix {
 
     // login
     public static final String API_V1_SSO_PREFIX = API_V1_PREFIX + "sso/";
-    public static final String API_V1_SSO_LOGIN = API_V1_SSO_PREFIX + "login";
-    public static final String API_V1_SSO_LOGOUT = API_V1_SSO_PREFIX + "logout";
 
     // console
     public static final String API_V1_NORMAL_PREFIX = API_V1_PREFIX + "normal/";

--- a/kafka-manager-extends/kafka-manager-account/src/main/java/com/xiaojukeji/kafka/manager/account/LoginService.java
+++ b/kafka-manager-extends/kafka-manager-account/src/main/java/com/xiaojukeji/kafka/manager/account/LoginService.java
@@ -16,5 +16,5 @@ public interface LoginService {
 
     void logout(HttpServletRequest request, HttpServletResponse response, Boolean needJump2LoginPage);
 
-    boolean checkLogin(HttpServletRequest request, HttpServletResponse response);
+    boolean checkLogin(HttpServletRequest request, HttpServletResponse response, String classRequestMappingValue);
 }

--- a/kafka-manager-extends/kafka-manager-account/src/main/java/com/xiaojukeji/kafka/manager/account/impl/LoginServiceImpl.java
+++ b/kafka-manager-extends/kafka-manager-account/src/main/java/com/xiaojukeji/kafka/manager/account/impl/LoginServiceImpl.java
@@ -63,19 +63,16 @@ public class LoginServiceImpl implements LoginService {
     }
 
     @Override
-    public boolean checkLogin(HttpServletRequest request, HttpServletResponse response) {
-        String uri = request.getRequestURI();
-        if (uri.contains("..") || uri.contains("./") || uri.contains("///")) {
-            LOGGER.error("class=LoginServiceImpl||method=checkLogin||msg=uri illegal, contains .. or ./ or ///||uri={}", uri);
+    public boolean checkLogin(HttpServletRequest request, HttpServletResponse response, String classRequestMappingValue) {
+        if (ValidateUtils.isNull(classRequestMappingValue)) {
+            LOGGER.error("class=LoginServiceImpl||method=checkLogin||msg=uri illegal||uri={}", request.getRequestURI());
             singleSignOn.setRedirectToLoginPage(response);
             return false;
         }
-        uri = uri.replaceAll("//", "/");
 
-        if (uri.equals(ApiPrefix.API_V1_SSO_LOGIN)
-                || uri.equals(ApiPrefix.API_V1_SSO_LOGOUT)
-                || uri.startsWith(ApiPrefix.API_V1_THIRD_PART_PREFIX)
-                || uri.startsWith(ApiPrefix.GATEWAY_API_V1_PREFIX)) {
+        if (classRequestMappingValue.equals(ApiPrefix.API_V1_SSO_PREFIX)
+                || classRequestMappingValue.equals(ApiPrefix.API_V1_THIRD_PART_PREFIX)
+                || classRequestMappingValue.equals(ApiPrefix.GATEWAY_API_V1_PREFIX)) {
             // 白名单接口直接true
             return true;
         }

--- a/kafka-manager-web/src/main/java/com/xiaojukeji/kafka/manager/web/inteceptor/PermissionInterceptor.java
+++ b/kafka-manager-web/src/main/java/com/xiaojukeji/kafka/manager/web/inteceptor/PermissionInterceptor.java
@@ -1,8 +1,13 @@
 package com.xiaojukeji.kafka.manager.web.inteceptor;
 
 import com.xiaojukeji.kafka.manager.account.LoginService;
+import com.xiaojukeji.kafka.manager.common.utils.ValidateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -15,6 +20,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Component
 public class PermissionInterceptor implements HandlerInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PermissionInterceptor.class);
+
     @Autowired
     private LoginService loginService;
 
@@ -28,6 +35,31 @@ public class PermissionInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request,
                              HttpServletResponse response,
                              Object handler) throws Exception {
-        return loginService.checkLogin(request, response);
+
+        String classRequestMappingValue = null;
+        try {
+            classRequestMappingValue = getClassRequestMappingValue(handler);
+        } catch (Exception e) {
+            LOGGER.error("class=PermissionInterceptor||method=preHandle||uri={}||msg=parse class request-mapping failed", request.getRequestURI(), e);
+        }
+        return loginService.checkLogin(request, response, classRequestMappingValue);
+    }
+
+    private String getClassRequestMappingValue(Object handler) {
+        RequestMapping classRM = null;
+        if(handler instanceof HandlerMethod) {
+            HandlerMethod hm = (HandlerMethod)handler;
+            classRM = hm.getMethod().getDeclaringClass().getAnnotation(RequestMapping.class);
+        } else if(handler instanceof org.springframework.web.servlet.mvc.Controller) {
+            org.springframework.web.servlet.mvc.Controller hm = (org.springframework.web.servlet.mvc.Controller)handler;
+            Class<? extends org.springframework.web.servlet.mvc.Controller> hmClass = hm.getClass();
+            classRM = hmClass.getAnnotation(RequestMapping.class);
+        } else {
+            classRM = handler.getClass().getAnnotation(RequestMapping.class);
+        }
+        if (ValidateUtils.isNull(classRM) || classRM.value().length < 0) {
+            return null;
+        }
+        return classRM.value()[0];
     }
 }


### PR DESCRIPTION
通过获取类的RequestMapping注解来判断当前请求是否需要登录，避免无序的HTTP请求导致部分接口登录检查被绕过