### PR TITLE
Topic删除功能优化

### DIFF
--- a/kafka-manager-core/src/main/java/com/xiaojukeji/kafka/manager/service/service/impl/AdminServiceImpl.java
+++ b/kafka-manager-core/src/main/java/com/xiaojukeji/kafka/manager/service/service/impl/AdminServiceImpl.java
@@ -143,6 +143,9 @@ public class AdminServiceImpl implements AdminService {
 
         // 4. 数据库中删除authority
         authorityService.deleteAuthorityByTopic(clusterDO.getId(), topicName);
+
+        // 5. 本地内存元信息中删除topic
+        PhysicalClusterMetadataManager.removeTopicMetadata(clusterDO.getId(), topicName);
         return rs;
     }
 


### PR DESCRIPTION
**问题：**
Topic从页面删除时，如果Kafka集群设置`auto.create.topics.enable=true`时，删除的Topic会自动创建回来
![image](https://user-images.githubusercontent.com/42090337/115377241-01470d00-a202-11eb-92ac-5986cfebc1ea.png)

**原因：**
在删除Topic时，没有将KM缓存在内存的Topic删掉，导致KM在删除Topic后，还会去请求Topic的元信息，使Topic重新创建回来

**解决方法：**
删除Topic时删除内存缓存的Topic